### PR TITLE
add a small sanity check for fens from input file

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -37,6 +37,9 @@ int main() {
       wordCount++;
     }
 
+    if (wordCount < 4)
+      continue;
+
     // start fen manipulation and DB access.
     std::cout << "-------------------------------------------------------------"
               << "\n";

--- a/main_threaded.cpp
+++ b/main_threaded.cpp
@@ -46,6 +46,8 @@ int main() {
       fen += word;
       wordCount++;
     }
+    if (wordCount < 4)
+      continue;
     nfen++;
     fens_chunked[nfen % fens_chunked.size()].push_back(fen);
   }


### PR DESCRIPTION
This PR introduces a small sanity check to avoid crashes.

For example, when parsing the file `FishtestLTC2020UniquePositions20PlySorted.epd` I got this with master:

```
-------------------------------------------------------------
Probing:
*** stack smashing detected ***: terminated
```

The reason are some weird (white) characters in the first line of that file:
```
> head -n 1 FishtestLTC2020UniquePositions20PlySorted.epd | hexdump
0000000 0000 0000 0000 0000 0000 0000 0000 0000
*
0000090 000a
0000091
```
