### PR TITLE
allow different input filenames

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -10,12 +10,18 @@
 
 #include "cdbdirect.h"
 
-int main() {
+int main(int argc, char *argv[]) {
 
   std::uintptr_t handle = cdbdirect_initialize(CHESSDB_PATH);
+  std::string filename = "caissa_sorted_100000.epd";
+
+  if (argc > 1)
+    filename = argv[1];
+
+  std::cout << "Reading FENs from: " << filename << std::endl;
 
   // open file with fen/epd
-  std::ifstream file("caissa_sorted_100000.epd");
+  std::ifstream file(filename);
   assert(file.is_open());
 
   std::string line;

--- a/main_threaded.cpp
+++ b/main_threaded.cpp
@@ -14,10 +14,13 @@
 
 #include "external/threadpool.hpp"
 
-int main() {
+int main(int argc, char *argv[]) {
 
   std::uintptr_t handle = cdbdirect_initialize(CHESSDB_PATH);
   std::string filename = "caissa_sorted_100000.epd";
+
+  if (argc > 1)
+    filename = argv[1];
 
   size_t num_threads = std::thread::hardware_concurrency();
 


### PR DESCRIPTION
Makes it a bit easier to analyse different files without the need to re-compile. Usage e.g. `./cdbdirect [filename]`.