### PR TITLE
add a function that returns the size of the DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,11 @@ Required time per fen: 2.08377 microsec.
 
 ### Interface
 
-The interface to probe has been kept very simple, with only 3 functions exposed by `cdbdirect.h`
+The interface to probe has been kept very simple, with only 4 functions exposed by `cdbdirect.h`
 
 ```
 std::uintptr_t cdbdirect_initialize(const std::string &path);
+std::uint64_t cdbdirect_size(std::uintptr_t handle);
 std::uintptr_t cdbdirect_finalize(std::uintptr_t handle);
 std::vector<std::pair<std::string, int>> cdbdirect_get(std::uintptr_t handle,
                                                        const std::string &fen);
@@ -103,7 +104,7 @@ A suitably prepared dump of the database.
 
 These dumps are large (>1TB) and will take several hours to download.
 
-* The following dump contains >40B chess positions
+* The following dump contains 44.3B chess positions
 ```
 wget -c -r -nH --cut-dirs=2 --no-parent --reject="index.html*" -e robots=off ftp://chessdb:chessdb@ftp.chessdb.cn/pub/chessdb/chess-20240814
 ```

--- a/cdbdirect.cpp
+++ b/cdbdirect.cpp
@@ -7,9 +7,9 @@
 #include <vector>
 
 #include "rocksdb/db.h"
+#include "rocksdb/filter_policy.h"
 #include "rocksdb/options.h"
 #include "rocksdb/table.h"
-#include "rocksdb/filter_policy.h"
 
 #include "cdbdirect.h"
 #include "fen2cdb.h"
@@ -35,6 +35,17 @@ std::uintptr_t cdbdirect_initialize(const std::string &path) {
   assert(s.ok());
 
   return reinterpret_cast<std::uintptr_t>(db);
+}
+
+// Return the size of the DB
+std::uint64_t cdbdirect_size(std::uintptr_t handle) {
+
+  DB *db = reinterpret_cast<DB *>(handle);
+
+  std::uint64_t size[1];
+  db->GetIntProperty("rocksdb.estimate-num-keys", size);
+
+  return size[0];
 }
 
 // Finalize the DB

--- a/cdbdirect.h
+++ b/cdbdirect.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 std::uintptr_t cdbdirect_initialize(const std::string &path);
+std::uint64_t cdbdirect_size(std::uintptr_t handle);
 std::uintptr_t cdbdirect_finalize(std::uintptr_t handle);
 std::vector<std::pair<std::string, int>> cdbdirect_get(std::uintptr_t handle,
                                                        const std::string &fen);

--- a/main_threaded.cpp
+++ b/main_threaded.cpp
@@ -16,7 +16,6 @@
 
 int main() {
 
-  std::uintptr_t handle = cdbdirect_initialize(CHESSDB_PATH);
   std::string filename = "caissa_sorted_100000.epd";
 
   size_t num_threads = std::thread::hardware_concurrency();
@@ -69,6 +68,10 @@ int main() {
 
   // Create a thread pool
   ThreadPool pool(num_threads);
+
+  std::uintptr_t handle = cdbdirect_initialize(CHESSDB_PATH);
+  std::uint64_t size = cdbdirect_size(handle);
+  std::cout << "Opened DB with " << size << " stored positions." << std::endl;
 
   // start probing
   std::cout << "Probing " << nfen << " fens with " << num_threads << " threads."


### PR DESCRIPTION
Sample output (for the August 2024 dump):
```
> ./cdbdirect_threaded 
Loading: caissa_sorted_100000.epd
Opened DB with 44262943988 stored positions.
Probing 100000 fens with 24 threads.
known fens:   100000
unknown fens: 0
scored moves: 2155937
Required probing time:         0.575567 sec.
Required time per fen: 5.75567 microsec.
Storing: unknown.epd
Closing DB
```