### PR TITLE
align mate and TB evaluations with chessdb GUI

### DIFF
--- a/cdbdirect.cpp
+++ b/cdbdirect.cpp
@@ -59,6 +59,15 @@ std::uintptr_t cdbdirect_finalize(std::uintptr_t handle) {
   return 0;
 }
 
+// scores outside of [-15000, 15000] are assumed to be (cursed) TB wins or mates
+int backprop_score(int child_score) {
+  if (child_score >= 15000)
+    return -child_score + 1;
+  if (child_score <= -15000)
+    return -child_score - 1;
+  return -child_score;
+}
+
 // Probe the DB, get back a vector of moves containing the known scored moves of
 // cdb fen: a position fen *without move counters* (as they have no meaning in
 // cdb) The result vector contains pairs of moves (algebraic notation) with
@@ -102,7 +111,7 @@ std::vector<std::pair<std::string, int>> cdbdirect_get(std::uintptr_t handle,
       if (pair.first != "a0a0") {
         result.push_back(
             std::make_pair(natural_order ? pair.first : cbgetBWmove(pair.first),
-                           -std::stoi(pair.second)));
+                           backprop_score(std::stoi(pair.second))));
       } else {
         ply = std::stoi(pair.second);
       }


### PR DESCRIPTION
The chessdb GUI shows the eval `29999` for mating moves. This PR makes cdbdirect behave the same. 

@vondele I am not sure if `backprop_score` is the best possible name. Feel free to change it or ask me to change it to a different name.

Patch:
```
> ./cdbdirect fool.epd 
Reading FENs from: fool.epd
-------------------------------------------------------------
Probing: rnbqkbnr/pppp1ppp/4p3/8/6P1/5P2/PPPPP2P/RNBQKBNR b KQkq -
    d8h4 : 29999
    h7h5 : 204
    b8c6 : 165
    d7d5 : 162
    e6e5 : 161
    f7f5 : 159
    c7c5 : 140
    a7a6 : 134
    f8e7 : 129
    f8c5 : 128
    h7h6 : 128
    a7a5 : 127
    b7b6 : 125
    d7d6 : 120
    g7g6 : 115
    f8d6 : 111
    b8a6 : 107
    g8h6 : 106
    f8b4 : 105
    c7c6 : 101
    g8e7 : 94
    b7b5 : 88
    g8f6 : 86
    d8e7 : 85
    d8f6 : 75
    d8g5 : 54
    f8a3 : 52
    f7f6 : 34
    g7g5 : -3
    e8e7 : -40
    Distance to startpos equal or less than 3
```

Master:
```
> ./cdbdirect fool.epd
Reading FENs from: fool.epd
-------------------------------------------------------------
Probing: rnbqkbnr/pppp1ppp/4p3/8/6P1/5P2/PPPPP2P/RNBQKBNR b KQkq -
    d8h4 : 30000
    h7h5 : 204
    b8c6 : 165
    d7d5 : 162
    e6e5 : 161
    f7f5 : 159
    c7c5 : 140
    a7a6 : 134
    f8e7 : 129
    f8c5 : 128
    h7h6 : 128
    a7a5 : 127
    b7b6 : 125
    d7d6 : 120
    g7g6 : 115
    f8d6 : 111
    b8a6 : 107
    g8h6 : 106
    f8b4 : 105
    c7c6 : 101
    g8e7 : 94
    b7b5 : 88
    g8f6 : 86
    d8e7 : 85
    d8f6 : 75
    d8g5 : 54
    f8a3 : 52
    f7f6 : 34
    g7g5 : -3
    e8e7 : -40
    Distance to startpos equal or less than 3
    ```