### PR TITLE
align min_ply output with api

### DIFF
--- a/cdbdirect.cpp
+++ b/cdbdirect.cpp
@@ -147,7 +147,8 @@ value_to_scoredMoves(const std::string &value, bool natural_order) {
 // root)
 // >=0 (shortest known distance to root)
 std::vector<std::pair<std::string, int>> cdbdirect_get(std::uintptr_t handle,
-                                                       const std::string &fen) {
+                                                       const std::string &fen,
+                                                       bool ply_cosmetics) {
 
   DB *db = reinterpret_cast<DB *>(handle);
 
@@ -168,7 +169,18 @@ std::vector<std::pair<std::string, int>> cdbdirect_get(std::uintptr_t handle,
 
   // If we have a hit decode the answer
   if (s.ok()) {
-    return value_to_scoredMoves(value, natural_order);
+    auto result = value_to_scoredMoves(value, natural_order);
+    if (ply_cosmetics) {
+      size_t n_elements = result.size();
+      int ply = result[n_elements - 1].second;
+      if (ply >= 0) {
+        // align ply value with api output
+        bool black_stm = fen.find(" w ") == std::string::npos;
+        if (black_stm != (ply % 2))
+          result[n_elements - 1].second++;
+      }
+    }
+    return result;
   }
 
   // signal failed probe.

--- a/cdbdirect.h
+++ b/cdbdirect.h
@@ -9,8 +9,9 @@
 std::uintptr_t cdbdirect_initialize(const std::string &path);
 std::uint64_t cdbdirect_size(std::uintptr_t handle);
 std::uintptr_t cdbdirect_finalize(std::uintptr_t handle);
-std::vector<std::pair<std::string, int>> cdbdirect_get(std::uintptr_t handle,
-                                                       const std::string &fen);
+std::vector<std::pair<std::string, int>>
+cdbdirect_get(std::uintptr_t handle, const std::string &fen,
+              bool ply_cosmetics = true);
 void cdbdirect_apply(
     std::uintptr_t handle, size_t num_threads,
     const std::function<bool(const std::string &,


### PR DESCRIPTION
I assume this is what @noobpwnftw does for api calls.

Patch:
```
-------------------------------------------------------------
Probing: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq -
    e7e5 : 1
    e7e6 : 1
    d7d5 : 1
    c7c5 : 1
    g8f6 : 1
    c7c6 : 0
    b7b6 : 0
    a7a6 : 0
    h7h6 : 0
    g7g6 : 0
    d7d6 : 0
    b8c6 : -1
    a7a5 : -1
    f7f5 : -1
    b7b5 : -1
    h7h5 : -2
    b8a6 : -5
    g8h6 : -5
    f7f6 : -25
    g7g5 : -199
    Distance to startpos equal or less than 1
```

Master:
```
-------------------------------------------------------------
Probing: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq -
    e7e5 : 1
    e7e6 : 1
    d7d5 : 1
    c7c5 : 1
    g8f6 : 1
    c7c6 : 0
    b7b6 : 0
    a7a6 : 0
    h7h6 : 0
    g7g6 : 0
    d7d6 : 0
    b8c6 : -1
    a7a5 : -1
    f7f5 : -1
    b7b5 : -1
    h7h5 : -2
    b8a6 : -5
    g8h6 : -5
    f7f6 : -25
    g7g5 : -199
    Distance to startpos equal or less than 0
```

Of course, this artificial result (mirrored start position), shows that even after the cosmetic correction the result can be wrong. In this case, the true min_ply would be much larger than 1.