### PR TITLE
Prototype python bindings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 TERARKDBROOT = /home/vondele/chess/noob/terarkdb
 
 # Needs to point to the path of the cdb dump
-CHESSDB_PATH = /mnt/ssd/chess-20250608/data
 CHESSDB_PATH = /mnt/ssd/chess-20251115/data
 
 # example executables
@@ -25,7 +24,7 @@ HEADERS = $(LIBHEADER) fen2cdb.h external/threadpool.hpp
 
 # tools
 CXX = g++
-CXXFLAGS = -O3 -g -Wall -march=native -fomit-frame-pointer -flto=auto
+CXXFLAGS = -O3 -g -Wall -march=native -fomit-frame-pointer -flto=auto -fPIC
 CXXFLAGS += -DCHESSDB_PATH=\"$(CHESSDB_PATH)\"
 AR = ar
 ARFLAGS = rcs

--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ Once prerequisites are available building is as simple as
 
 ```bash
 make -j
+# for python bindings:
+pip install .
+
 ```
 
 ## Prerequisites
@@ -139,7 +142,7 @@ These dumps are large (~1TB, >50B positions) and might take several hours to dow
 * Dumps can be obtained from [Hugging Face](https://huggingface.co/datasets/robertnurnberg/chessdbcn).
 
 ```bash
-hf download --repo-type dataset robertnurnberg/chessdbcn --local-dir . --cache-dir . --include "chess-20250608/**"
+hf download --repo-type dataset robertnurnberg/chessdbcn --local-dir . --cache-dir . --include "chess-20251115/**"
 ```
 
 * Alternatively, and slower, at the chessdb source:
@@ -177,15 +180,22 @@ On Ubuntu, install the needed prerequisites:
 
 ```bash
 sudo apt-get install libboost-fiber-dev libtbb-dev autoconf cmake build-essential curl git
+pip install pybind11
 ```
 
-Clone noobpwnftw's terakdb repo and build it
+Clone noobpwnftw's terakdb repo and build it (using position independent code, as it will be linked into a shared library):
 
 ```bash
+export CFLAGS="-fPIC $CFLAGS" && export CXXFLAGS="-fPIC $CXXFLAGS" && export EXTRA_CFLAGS="-fPIC" && export EXTRA_CXXFLAGS="-fPIC"
 git clone --depth 1 https://github.com/noobpwnftw/terarkdb.git
 cd terarkdb
 ./build.sh
 ```
 
-After building, ensure this repo's Makefile variables `TERARKDBROOT` and `CHESSDB_PATH` point to `/the/full/path/of/terarkdb/`
-and the path of the DB dump, respectively.
+After building, ensure this repo's Makefile / setup.py variables `TERARKDBROOT` and `CHESSDB_PATH` point to `/the/full/path/of/terarkdb/`
+and the path of the DB dump, respectively. For example:
+
+```bash
+export TERARKDBROOT=/home/vondele/chess/noob/terarkdb
+export CHESSDB_PATH=/mnt/ssd/chess-20251115/data
+```

--- a/binding.cpp
+++ b/binding.cpp
@@ -1,0 +1,69 @@
+#include "cdbdirect.h"
+#include <mutex>
+#include <optional>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <thread>
+
+namespace py = pybind11;
+
+class CDB {
+public:
+  CDB(const std::string &path, std::optional<size_t> threads) {
+    m_threads = threads.value_or(
+        std::max((unsigned int)1, std::thread::hardware_concurrency()));
+    m_handle = cdbdirect_initialize(path);
+    if (!m_handle)
+      throw std::runtime_error("Init failed: " + path);
+  }
+
+  ~CDB() {
+    if (m_handle)
+      cdbdirect_finalize(m_handle);
+  }
+
+  uint64_t size() const { return cdbdirect_size(m_handle); }
+  auto get(const std::string &fen) { return cdbdirect_get(m_handle, fen); }
+
+  void apply(py::function callback) {
+    // We use a pointer to avoid GIL issues during lambda capture/copy
+    py::function *callback_ptr = &callback;
+
+    // This mutex guarantees SERIALIZED access to the Python callback
+    // from the multiple C++ worker threads.
+    std::mutex python_mutex;
+
+    auto cpp_callback =
+        [&](const std::string &fen,
+            const std::vector<std::pair<std::string, int>> &entries) -> bool {
+      // 1. Wait for our turn to use the Python interpreter
+      std::lock_guard<std::mutex> lock(python_mutex);
+
+      // 2. Acquire GIL
+      py::gil_scoped_acquire acquire;
+
+      try {
+        // 3. Execute (py::cast handles the deep copy safely)
+        return (*callback_ptr)(fen, py::cast(entries)).cast<bool>();
+      } catch (py::error_already_set &e) {
+        return false;
+      }
+    };
+
+    py::gil_scoped_release release;
+    cdbdirect_apply(m_handle, m_threads, cpp_callback);
+  }
+
+private:
+  std::uintptr_t m_handle;
+  size_t m_threads;
+};
+
+PYBIND11_MODULE(cdbdirect, m) {
+  py::class_<CDB>(m, "CDB")
+      .def(py::init<const std::string &, std::optional<size_t>>(),
+           py::arg("path"), py::arg("threads") = py::none())
+      .def("size", &CDB::size)
+      .def("get", &CDB::get)
+      .def("apply", &CDB::apply);
+}

--- a/cdb4py.py
+++ b/cdb4py.py
@@ -1,0 +1,43 @@
+import os
+import time
+import cdbdirect
+
+# 1. Setup Path
+default_path = "/mnt/ssd/chess-20251115/data"
+db_path = os.environ.get("CHESSDB_PATH", default_path)
+
+db = cdbdirect.CDB(db_path)
+print(f"Database contains {db.size()} entries.")
+
+print("Startpos: ", db.get("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -"))
+
+count = 0
+limit = 100000
+
+
+# the interface is such that only one c++ thread will call this function at a time.
+def process(fen, entries):
+    global count, limit
+
+    # Check if we already hit the limit on another thread
+    if count >= limit:
+        return False
+
+    count += 1
+    if False:
+        print(f"[{count}] Processing FEN: {fen}")
+        for move, score in entries:
+            print(f"  -> {move}: {score}")
+
+    return limit > count
+
+
+# 3. Run
+print(f"Starting batch process (limit: {limit})...")
+start_time = time.time()
+db.apply(process)
+end_time = time.time()
+print(
+    f"Batch process completed in {end_time - start_time:.2f} seconds. Speed {limit / (end_time - start_time):.2f} entries/sec."
+)
+print("Done.")

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,75 @@
+import os
+import sys
+from setuptools import setup
+from pybind11.setup_helpers import Pybind11Extension, build_ext
+
+# 1. Capture your environment variables
+terark_root = os.environ.get("TERARKDBROOT", "/home/vondele/chess/noob/terarkdb")
+# Ensure the compiler matches your Makefile
+os.environ["CC"] = "g++"
+os.environ["CXX"] = "g++"
+
+# 2. Extract the library names from your LIBS string
+# (Removing the '-l' prefix)
+libraries = [
+    "cdbdirect",
+    "terarkdb",
+    "terark-zip-r",
+    "boost_fiber",
+    "boost_context",
+    "tbb",
+    "snappy",
+    "lz4",
+    "z",
+    "bz2",
+    "atomic",
+]
+
+# Standard system libs often handled by the compiler but safe to include
+system_libs = ["pthread", "rt", "dl", "gomp"]
+all_libs = libraries + system_libs
+
+ext_modules = [
+    Pybind11Extension(
+        "cdbdirect",
+        ["binding.cpp"],
+        # Corresponds to -I flags
+        include_dirs=[
+            #    os.path.join(terark_root, "output/include"),
+            #    os.path.join(terark_root, "third-party/terark-zip/src"),
+            #    os.path.join(terark_root, "include"),
+            ".",
+        ],
+        # Corresponds to -L flags
+        library_dirs=[
+            ".",
+            os.path.join(terark_root, "output/lib"),
+        ],
+        # Corresponds to -l flags
+        libraries=all_libs,
+        # Corresponds to CXXFLAGS
+        extra_compile_args=[
+            "-O3",
+            "-march=native",
+            "-fomit-frame-pointer",
+            "-fPIC",
+            "-flto=auto",
+        ],
+        # Matches your Makefile's LTO and specific path define
+        extra_link_args=["-flto=auto"],
+        define_macros=[
+            (
+                "CHESSDB_PATH",
+                os.environ.get("CHESSDB_PATH", "/mnt/ssd/chess-20251115/data"),
+            )
+        ],
+        cxx_std=17,  # Adjust to 11, 14, or 17 based on your project
+    ),
+]
+
+setup(
+    name="cdbdirect",
+    version="0.1",
+    ext_modules=ext_modules,
+    cmdclass={"build_ext": build_ext},
+)


### PR DESCRIPTION
relies on pybind11, requires dependencies to be compiled with -fPIC. (See readme) Not compatible we jemalloc for now.
apply() is particularly slow compared to the c++ version.

Install with `pip install .`
otherwise quite straightforward to use, it seems (see cdb4py.py)