### PR TITLE
disable asserts in prod, allow debug builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,12 @@ HEADERS = $(LIBHEADER) fen2cdb.h external/threadpool.hpp
 
 # tools
 CXX = g++
-CXXFLAGS = -O3 -g -Wall -march=native -fomit-frame-pointer -flto=auto -fPIC
-CXXFLAGS += -DCHESSDB_PATH=\"$(CHESSDB_PATH)\"
+CXXFLAGS = -Wall -flto=auto -fPIC -DCHESSDB_PATH=\"$(CHESSDB_PATH)\"
+ifdef DEBUG
+  CXXFLAGS += -O0 -g3 -UNDEBUG
+else
+  CXXFLAGS += -O3 -g -DNDEBUG -march=native -fomit-frame-pointer
+endif
 AR = ar
 ARFLAGS = rcs
 
@@ -34,7 +38,7 @@ INCFLAGS = -I$(TERARKDBROOT)/output/include -I$(TERARKDBROOT)/third-party/terark
 LDFLAGS = -L$(TERARKDBROOT)/output/lib
 LIBS = -lterarkdb -lterark-zip-r -lboost_fiber -lboost_context -ljemalloc -pthread -lgcc -lrt -ldl -ltbb -lgomp -lsnappy -llz4 -lz -lbz2 -latomic
 
-.PHONY = all lib clean format
+.PHONY: all lib clean format
 
 all: $(EXE1) $(EXE2) $(EXE3) lib
 

--- a/cdbdirect.cpp
+++ b/cdbdirect.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cassert>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -49,9 +50,10 @@ std::uintptr_t cdbdirect_initialize(const std::string &path) {
 
   // open DB
   Status s = DB::OpenForReadOnly(options, path, &db);
-  if (!s.ok())
+  if (!s.ok()) {
     std::cerr << s.ToString() << std::endl;
-  assert(s.ok());
+    std::exit(1);
+  }
 
   return reinterpret_cast<std::uintptr_t>(db);
 }

--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <chrono>
 #include <cstdint>
 #include <fstream>
@@ -22,7 +21,10 @@ int main(int argc, char *argv[]) {
 
   // open file with fen/epd
   std::ifstream file(filename);
-  assert(file.is_open());
+  if (!file.is_open()) {
+    std::cerr << "Error: Unable to open file." << std::endl;
+    return 1;
+  }
 
   std::string line;
   while (std::getline(file, line)) {

--- a/main_threaded.cpp
+++ b/main_threaded.cpp
@@ -1,5 +1,4 @@
 #include <atomic>
-#include <cassert>
 #include <chrono>
 #include <cstdint>
 #include <fstream>
@@ -23,14 +22,18 @@ int main(int argc, char *argv[]) {
   if (argc > 1)
     filename = argv[1];
 
-  size_t num_threads = std::thread::hardware_concurrency();
-
   // open file with fen/epd
-  std::vector<std::vector<std::string>> fens_chunked;
-  fens_chunked.resize(num_threads * 20);
   std::cout << "Loading: " << filename << std::endl;
   std::ifstream file(filename);
-  assert(file.is_open());
+  if (!file.is_open()) {
+    std::cerr << "Error: Unable to open file." << std::endl;
+    return 1;
+  }
+
+  size_t num_threads = std::thread::hardware_concurrency();
+  std::vector<std::vector<std::string>> fens_chunked;
+  fens_chunked.resize(num_threads * 20);
+
   std::string line;
   size_t nfen = 0;
   while (std::getline(file, line)) {
@@ -55,7 +58,6 @@ int main(int argc, char *argv[]) {
     nfen++;
     fens_chunked[nfen % fens_chunked.size()].push_back(fen);
   }
-
   file.close();
 
   // keep a list of known fens to store later
@@ -133,8 +135,13 @@ int main(int argc, char *argv[]) {
     eval_map[tuple.first] = tuple.second;
   }
 
-  std::ofstream ofile("cdbdirect.epd");
-  assert(ofile.is_open());
+  std::string ofilename = "cdbdirect.epd";
+  std::ofstream ofile(ofilename);
+  if (!ofile.is_open()) {
+    std::cerr << "Error: Unable to open file" << ofilename << "." << std::endl;
+    return 1;
+  }
+
   file.open(filename);
   while (std::getline(file, line)) {
     std::istringstream iss(line);
@@ -167,7 +174,7 @@ int main(int argc, char *argv[]) {
     ofile << ";\n";
   }
   ofile.close();
-  std::cout << "Known evals written to cdbdirect.epd." << std::endl;
+  std::cout << "Known evals written to " << ofilename << "." << std::endl;
 
   // Close DB
   std::cout << "Closing DB" << std::endl;


### PR DESCRIPTION
Default `make` now yields production builds, with asserts disabled. Running `make DEBUG=1` gives debug builds with asserts enabled.